### PR TITLE
add promise reject by catch for plyql-mysql-gateway

### DIFF
--- a/src/plyql-mysql-gateway.ts
+++ b/src/plyql-mysql-gateway.ts
@@ -137,6 +137,12 @@ export function plyqlMySQLGateway(port: number, context: Datum, timezone: Timezo
             } else {
               throw new Error('unexpected result from expression');
             }
+          })
+          .catch((e) => {
+            conn.writeError({
+              code: 1146,
+              message: e.message
+            });
           });
         return;
 


### PR DESCRIPTION
add catch code so that promise will reject if error occurs.
If not,plyql mysql gateway will hang the request when a query executed with not existed datasource.